### PR TITLE
Potential fix for installation error in VS2013

### DIFF
--- a/CommentReflower/source.extension.vsixmanifest
+++ b/CommentReflower/source.extension.vsixmanifest
@@ -13,7 +13,7 @@
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0, 14.0]" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     <Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="11.0" />
   </Dependencies>
   <Assets>


### PR DESCRIPTION
When installing in VS2013 from the Visual Studio Gallery within VS I receive an error message: "The extension could not be installed because the following error occurred: The extension 'Comment Reflower' requires a version of the .NET Framework that is not installed."

However, if I download the VSIX from the gallery in a web browser and then run the VSIX from Windows Explorer it installs with no problems. After a bit of research this appears to be related to the way the required .NET Framework version is specified e.g. https://visualstudiogallery.msdn.microsoft.com/1290e058-33da-485f-9b75-1891abc947b3?SRC=VSIDE

I've tested the change locally and it installs successfully, but the real test would be to update it in the gallery and try to install from there.
